### PR TITLE
Vaccum auto-start, covid version

### DIFF
--- a/automations/vacuumCleaner.yaml
+++ b/automations/vacuumCleaner.yaml
@@ -112,3 +112,24 @@
   - service: script.turn_on
     data:
       entity_id: script.vacuum_kitchen_and_diningroom
+- id: vacuum_kitchen_and_dining_room_when_we_are_away_covid_version
+  alias: vacuum Kitchen and dining room when we are away (Covid version)
+  trigger:
+  - platform: state
+    entity_id: person.giom_2, person.claire_2
+    to: not_home
+    for:
+      minutes: 5
+  condition:
+  - condition: state
+    entity_id: binary_sensor.people_home
+    state: 'on'
+  - condition: state
+    entity_id: vacuum.xiaomi_vacuum_cleaner
+    state: 'docked'
+    for:
+      hours: 10
+  action:
+  - service: script.turn_on
+    data:
+      entity_id: script.vacuum_kitchen_and_diningroom

--- a/automations/vacuumCleaner.yaml
+++ b/automations/vacuumCleaner.yaml
@@ -122,9 +122,6 @@
       minutes: 5
   condition:
   - condition: state
-    entity_id: binary_sensor.people_home
-    state: 'on'
-  - condition: state
     entity_id: vacuum.xiaomi_vacuum_cleaner
     state: 'docked'
     for:


### PR DESCRIPTION
with failsafe so that it only triggers once every 10 hours