### PR TITLE
Replacing base_url by external/internal_url

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -20,6 +20,8 @@ homeassistant:
     - !secret externalDirShare
     - !secret externalDirTmp
     - !secret externalDirDafang
+  external_url: !secret base_url
+  internal_url: !secret internal_url 
   auth_providers:
     - type: trusted_networks
       trusted_networks:

--- a/integrations/http.yaml
+++ b/integrations/http.yaml
@@ -1,8 +1,6 @@
 # https://home-assistant.io/components/http/
 
 http:
-  external_url: !secret base_url
-  internal_url: !secret internal_url 
   ip_ban_enabled: true
   trusted_proxies:
     - 192.168.86.0/24 #TODO: secret?

--- a/integrations/http.yaml
+++ b/integrations/http.yaml
@@ -1,7 +1,8 @@
 # https://home-assistant.io/components/http/
 
 http:
-  base_url: !secret base_url
+  external_url: !secret base_url
+  internal_url: !secret internal_url 
   ip_ban_enabled: true
   trusted_proxies:
     - 192.168.86.0/24 #TODO: secret?

--- a/secrets.fake.yaml
+++ b/secrets.fake.yaml
@@ -2,7 +2,7 @@
 # Learn more at https://home-assistant.io/docs/configuration/secrets/
 airvisual_APIKey: xyz
 azure_APIKey: xyz
-base_url: x.y:0000
+base_url: https://0.0.0.0:0000
 claireUserId: 0
 claireWorkplaceGPSCoordinates: 00.00, 00.00
 dafangImageUrl: http://0.0.0.0
@@ -37,7 +37,7 @@ homeLongitude: 00.00
 http_password: xyz
 IBM_APIKey: xyz
 ifttt_APIKey: xyz
-internal_url: 0.0.0.0:0000
+internal_url: https://0.0.0.0:0000
 linkyLaPlagnePassword: xyz
 linkyLaPlagneUsername: x@y.z
 mqttPassword: xyz

--- a/secrets.fake.yaml
+++ b/secrets.fake.yaml
@@ -37,6 +37,7 @@ homeLongitude: 00.00
 http_password: xyz
 IBM_APIKey: xyz
 ifttt_APIKey: xyz
+internal_url: 0.0.0.0:0000
 linkyLaPlagnePassword: xyz
 linkyLaPlagneUsername: x@y.z
 mqttPassword: xyz


### PR DESCRIPTION
Fixing https://trello.com/c/odG41AHl aka.
> WARNING:homeassistant.components.http:The 'base_url' option is deprecated, please remove it from your configuration