### PR TITLE
[HA-61] feat(visitors)/ Enable visitors mode during away mode

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -484,6 +484,9 @@
   - trigger: state
     entity_id:
     - input_boolean.away_mode
+  - trigger: state
+    entity_id:
+    - input_boolean.visitors
   conditions: []
   actions:
   - if:
@@ -491,6 +494,10 @@
       entity_id: input_boolean.away_mode
       state:
       - 'on'
+    - condition: state
+      entity_id: input_boolean.visitors
+      state:
+      - 'off'
     then:
     - action: switch.turn_off
       metadata: {}
@@ -511,6 +518,9 @@
   - trigger: state
     entity_id:
     - input_boolean.away_mode
+  - trigger: state
+    entity_id:
+    - input_boolean.visitors
   conditions: []
   actions:
   - if:
@@ -518,6 +528,10 @@
       entity_id: input_boolean.away_mode
       state:
       - 'on'
+    - condition: state
+      entity_id: input_boolean.visitors
+      state:
+      - 'off'
     then:
     - action: switch.turn_on
       metadata: {}

--- a/automations/away_mode.yaml
+++ b/automations/away_mode.yaml
@@ -622,6 +622,9 @@
     - condition: state
       entity_id: input_boolean.away_mode
       state: "on"
+    - condition: state
+      entity_id: input_boolean.visitors
+      state: "off"
     - condition: and
       conditions:
         - condition: numeric_state

--- a/automations/visitors.md
+++ b/automations/visitors.md
@@ -32,6 +32,16 @@ impacted by the `input_boolean.visitors` value:
   not run if `input_boolean.visitors` is `on`.
 * [**Presence simulation Aurore's bedroom**](away_mode.yaml#L411): This
   automation will not run if `input_boolean.visitors` is `on`.
+* [**Garage: Turn off power if user moves away after pre-arrival**](away_mode.yaml#L611):
+  This automation will not run if `input_boolean.visitors` is `on`.
+
+The following automations from the [`automations.yaml`](../automations.yaml) file are
+impacted by the `input_boolean.visitors` value:
+
+* [**Block the garage door when we are away**](../automations.yaml): This automation
+  will keep the garage power ON if `input_boolean.visitors` is `on`.
+* [**Turn on/off camera when we are away**](../automations.yaml): This automation
+  will keep the camera sirens and notifications OFF if `input_boolean.visitors` is `on`.
 
 ## Vacuum Cleaner Automations
 


### PR DESCRIPTION
This PR enables the visitors mode to work correctly when the house is in away mode.
Specifically, when `input_boolean.visitors` is ON:
- The garage door power remains ON (or is turned back ON) if the house is in away mode.
- The camera sirens and notifications remain OFF (or are turned OFF) if the house is in away mode.

Other alarms/alerts (motion, door open) were already handling the visitors boolean and remain unchanged.

Modifications:
- Updated 'Block the garage door when we are away' in `automations.yaml`.
- Updated 'Turn on/off camera when we are away' in `automations.yaml`.
- Updated 'Garage: Turn off power if user moves away after pre-arrival' in `automations/away_mode.yaml`.
- Updated `automations/visitors.md` documentation.

---
*PR created automatically by Jules for task [15342960671121105392](https://jules.google.com/task/15342960671121105392) started by @Giom-V*