### PR TITLE
[HA-64] feat(bassin): Add failsafe scripts for pond fountain control

### DIFF
--- a/automations/bassin.yaml
+++ b/automations/bassin.yaml
@@ -26,9 +26,7 @@
       entity_id: sensor.module_exterieur_netatmo_temperature
       above: 0
   actions:
-    - service: switch.turn_on
-      target:
-        entity_id: switch.fontaine_bassin
+    - action: script.turn_on_pond_fountain
   mode: single
 - id: pond_pump_off_peak
   alias: Turn off the pond's pump during peak hours
@@ -44,9 +42,7 @@
       entity_id: binary_sensor.heure_creuse
       state: "off"
   actions:
-    - service: switch.turn_off
-      target:
-        entity_id: switch.fontaine_bassin
+    - action: script.turn_off_pond_fountain
   mode: single
 - id: pond_pump_off_freezing
   alias: Turn off water pump when it's freezing
@@ -59,9 +55,7 @@
         minutes: 5
   conditions: []
   actions:
-    - service: switch.turn_off
-      target:
-        entity_id: switch.fontaine_bassin
+    - action: script.turn_off_pond_fountain
   mode: single
 - id: pond_pump_on_lunchtime
   alias: Turn on pond's pump when we are here during lunch time
@@ -79,9 +73,7 @@
           entity_id: binary_sensor.people_home
           state: "on"
   actions:
-    - service: switch.turn_on
-      target:
-        entity_id: switch.fontaine_bassin
+    - action: script.turn_on_pond_fountain
   mode: single
 - id: pond_pump_scare_animals
   alias: Turn on water pump for 5mn to scare animals
@@ -102,9 +94,7 @@
       entity_id: binary_sensor.terrasse_person
       state: "off"
   actions:
-    - service: switch.turn_on
-      target:
-        entity_id: switch.fontaine_bassin
+    - action: script.turn_on_pond_fountain
     - delay:
         minutes: 5
     - if:
@@ -112,7 +102,5 @@
           entity_id: binary_sensor.heure_creuse
           state: "off"
       then:
-        - service: switch.turn_off
-          target:
-            entity_id: switch.fontaine_bassin
+        - action: script.turn_off_pond_fountain
   mode: restart

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,11 @@ The other script cycle between the [colored scenes](../scenes/LivingRoom.yaml) w
 Those scripts are meant to send pictures of the sunset/sunrise on Slack everyday.
 There's also another script that should be creating a daily gif and send it to slack but it doesn't work at the moment.
 
+### [Bassin.yaml](bassin.yaml)
+
+These scripts provide a safe way to turn on and off the pond's fountain (`switch.fontaine_bassin`).
+They fall back to a failsafe entity (`light.pompe_failsafe_light`) if the primary switch is unavailable or fails to change state after 1 minute.
+
 ### [Vacuum.yaml](vacuum.yaml)
 
 The first script (`vacuum_dispatch`), looks for keywords in the text received from IFTTT through a webhook (managed by the [`IFTTT_zone_cleaning_webhook` automation](../automations/vacuumCleaner.yaml)) and then runs one of the other scripts depending on the rooms that we want to clean.

--- a/scripts/bassin.yaml
+++ b/scripts/bassin.yaml
@@ -1,0 +1,56 @@
+turn_on_pond_fountain:
+  alias: Turn on the pond's fountain
+  sequence:
+    - if:
+        - condition: state
+          entity_id: switch.fontaine_bassin
+          state: unavailable
+      then:
+        - action: light.turn_on
+          target:
+            entity_id: light.pompe_failsafe_light
+      else:
+        - action: switch.turn_on
+          target:
+            entity_id: switch.fontaine_bassin
+        - wait_template: "{{ is_state('switch.fontaine_bassin', 'on') }}"
+          timeout: '00:01:00'
+        - if:
+            - condition: not
+              conditions:
+                - condition: state
+                  entity_id: switch.fontaine_bassin
+                  state: 'on'
+          then:
+            - action: light.turn_on
+              target:
+                entity_id: light.pompe_failsafe_light
+  icon: mdi:fountain
+turn_off_pond_fountain:
+  alias: Turn off the pond's fountain
+  sequence:
+    - if:
+        - condition: state
+          entity_id: switch.fontaine_bassin
+          state: unavailable
+      then:
+        - action: light.turn_off
+          target:
+            entity_id: light.pompe_failsafe_light
+      else:
+        - action: switch.turn_off
+          target:
+            entity_id: switch.fontaine_bassin
+        - wait_template: "{{ is_state('switch.fontaine_bassin', 'off') }}"
+          timeout: '00:01:00'
+        - if:
+            - condition: not
+              conditions:
+                - condition: state
+                  entity_id: switch.fontaine_bassin
+                  state: 'off'
+          then:
+            - action: light.turn_off
+              target:
+                entity_id: light.pompe_failsafe_light
+  icon: mdi:fountain


### PR DESCRIPTION
This PR introduces two new scripts to safely control the pond's fountain (`switch.fontaine_bassin`). 

If the primary switch is unavailable or fails to achieve the desired state within 1 minute, the scripts will automatically fall back to the backup failsafe entity (`light.pompe_failsafe_light`). 

All existing automations within `automations/bassin.yaml` that controlled the fountain have been updated to utilize these new scripts, ensuring consistent fallback behavior across the board. The documentation in `scripts/README.md` has also been updated to reflect these additions.

---
*PR created automatically by Jules for task [5967595670780372533](https://jules.google.com/task/5967595670780372533) started by @Giom-V*