### PR TITLE
[HA-61] feat/ Implement visitors override during away mode

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -137,6 +137,9 @@
   - condition: state
     entity_id: input_boolean.away_mode
     state: 'on'
+  - condition: state
+    entity_id: input_boolean.visitors
+    state: 'off'
   - data:
       message: Intrusion confirmée ! Dernier avertissement avant appel de la police
         !
@@ -206,6 +209,9 @@
   - condition: state
     entity_id: input_boolean.away_mode
     state: 'on'
+  - condition: state
+    entity_id: input_boolean.visitors
+    state: 'off'
   - data:
       message: Intrusion confirmée ! Dernier avertissement avant appel de la police
         !
@@ -280,6 +286,9 @@
   - condition: state
     entity_id: input_boolean.away_mode
     state: 'on'
+  - condition: state
+    entity_id: input_boolean.visitors
+    state: 'off'
   - data:
       message: Intrusion confirmée ! Dernier avertissement avant appel de la police
         !
@@ -484,6 +493,7 @@
   - trigger: state
     entity_id:
     - input_boolean.away_mode
+    - input_boolean.visitors
   conditions: []
   actions:
   - if:
@@ -491,6 +501,10 @@
       entity_id: input_boolean.away_mode
       state:
       - 'on'
+    - condition: state
+      entity_id: input_boolean.visitors
+      state:
+      - 'off'
     then:
     - action: switch.turn_off
       metadata: {}
@@ -511,6 +525,7 @@
   - trigger: state
     entity_id:
     - input_boolean.away_mode
+    - input_boolean.visitors
   conditions: []
   actions:
   - if:
@@ -518,6 +533,10 @@
       entity_id: input_boolean.away_mode
       state:
       - 'on'
+    - condition: state
+      entity_id: input_boolean.visitors
+      state:
+      - 'off'
     then:
     - action: switch.turn_on
       metadata: {}

--- a/automations/visitors.md
+++ b/automations/visitors.md
@@ -33,6 +33,22 @@ impacted by the `input_boolean.visitors` value:
 * [**Presence simulation Aurore's bedroom**](away_mode.yaml#L411): This
   automation will not run if `input_boolean.visitors` is `on`.
 
+## Other Automations
+
+The following automations from the [`../automations.yaml`](../automations.yaml)
+file are impacted by the `input_boolean.visitors` value:
+
+* **Alarme - Intrusion détectée (Away Mode)**: This automation will not run if
+  `input_boolean.visitors` is `on`.
+* **Alarme - Mouvement détectée (Away Mode)**: This automation will not run if
+  `input_boolean.visitors` is `on`.
+* **Alarme - Lumière allumée détectée (Away Mode)**: This automation will not
+  run if `input_boolean.visitors` is `on`.
+* **Block the garage door when we are away**: This automation will unblock the
+  garage door if `input_boolean.visitors` is `on`.
+* **Turn on/off camera when we are away**: This automation will not turn on the
+  cameras if `input_boolean.visitors` is `on`.
+
 ## Vacuum Cleaner Automations
 
 The following vacuum cleaner automation is impacted by the


### PR DESCRIPTION
Updates automations to seamlessly override `away_mode` when `input_boolean.visitors` is activated. Alarms, garage blocking, and camera sirens will not operate while guests are present, and will revert to normal operation after guests leave.

---
*PR created automatically by Jules for task [1931826060077418195](https://jules.google.com/task/1931826060077418195) started by @Giom-V*