### PR TITLE
[HA-63] feat: add bedtime meditation automation and update remote mapping

### DIFF
--- a/automations/chambre_aurore.yaml
+++ b/automations/chambre_aurore.yaml
@@ -260,3 +260,56 @@
       target:
         entity_id: cover.velux_external_cover_roller_shutter
   mode: single
+- id: "1769000000001"
+  alias: "Aurore - Histoire aléatoire du soir"
+  description: "Joue une histoire aléatoire choisie par Aurore sur son enceinte à 22h00"
+  mode: single
+  trigger:
+    - platform: time
+      at: "22:00:00"
+  action:
+    - action: media_player.volume_set
+      target:
+        entity_id: media_player.enceinte_aurore_2
+      data:
+        volume_level: 0.2
+    - action: music_assistant.play_media
+      target:
+        entity_id: media_player.enceinte_aurore_2
+      data:
+        media_type: track
+        enqueue: replace
+        radio_mode: false
+        media_id: >
+          {{ [
+            "Imagine que tu es un super héro - Quand on a besoin de courage",
+            "Imagine que tu es un super héro - Quand on a besoin de courage",
+            "Imagine que tu as le pouvoir de te transformer en animal - Quand on a besoin de force",
+            "Imagine queque tu as des lunettes à émotions - Quand on a envie d'aider les autres",
+            "Imagine queque tu as des lunettes à émotions - Quand on a envie d'aider les autres",
+            "Imagine que tu as le pouvoir d'être invisible - Quand on a envie d'assouvir sa curiosité",
+            "Imagine que tu as le pouvoir d'être invisible - Quand on a envie d'assouvir sa curiosité",
+            "Imagine que tu peux respirer sous l'eau - Quand on a besoin de s'évader",
+            "Imagine que tu peux voir dans le noir - Quand on a peur du noir",
+            "Imagine que tu peux voir dans le noir - Quand on a peur du noir",
+            "Imagine que tu es loup",
+            "Imagine que tu es une étoile de mer",
+            "Imagine que tu es une étoile de mer",
+            "Imagine que tu es un éléphant",
+            "Imagine que tu es un éléphant",
+            "Imagine que tu es dinosaure",
+            "Imagine que tu es un oiseau",
+            "Imagine que tu es un oiseau",
+            "Imagine que tu es une chenille",
+            "Imagine que tu es une chenille",
+            "Imagine que tu es un nuage - Traverser des épreuves grâce à l'amitié et l'entraide",
+            "Imagine que tu traverses le feu - Faire preuve de courage",
+            "Imagine que tu es un arbre - Adopter la nature comme refuge",
+            "Imagine que tu rêves d'espace - Quand on a besoin de temps pour rêver",
+            "Imagine que tu es une étoile perdue - Quand on se sent un peu perdu",
+            "Imagine que tu es une étoile perdue - Quand on se sent un peu perdu",
+            "Imagine que tu es le soleil - Quand on déborde d'énergie",
+            "Imagine que tu passes près d'un trou noir - Quand on a besoin de force",
+            "Imagine que tu passes près d'un trou noir - Quand on a besoin de force",
+            "Imagine que tu te transforme en Pluton - Quand on a besoin de se retrouver"
+          ] | random }}

--- a/automations/chambre_aurore.yaml
+++ b/automations/chambre_aurore.yaml
@@ -128,24 +128,56 @@
       platform: device
       type: remote_button_short_press
       subtype: left
+      id: "short"
+    - device_id: e059cad12f0a2c750a56719a911dc8e6
+      domain: zha
+      platform: device
+      type: remote_button_long_press
+      subtype: left
+      id: "long"
   condition: []
   action:
-    - if:
-        - condition: device
-          device_id: 8f16b93c4fae1055fc21ef57afca5b0f
-          domain: cover
-          entity_id: 5159b1462f01722c359983c04fea0e28
-          type: is_closed
-      then:
-        - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
-          domain: cover
-          entity_id: 5159b1462f01722c359983c04fea0e28
-          type: open
-      else:
-        - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
-          domain: cover
-          entity_id: 5159b1462f01722c359983c04fea0e28
-          type: close
+    - choose:
+        - conditions:
+            - condition: trigger
+              id: "short"
+          sequence:
+            - if:
+                - condition: device
+                  device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: is_closed
+              then:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: open
+              else:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: close
+        - conditions:
+            - condition: trigger
+              id: "long"
+          sequence:
+            - if:
+                - condition: device
+                  device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: is_closed
+              then:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: close
+              else:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: open
   mode: single
 - id: "1758443142653"
   alias: Switch off Aurore bed light when she sleeps
@@ -208,8 +240,8 @@
         entity_id: cover.velux_external_cover_roller_shutter
   mode: single
 - id: "1769000000001"
-  alias: "Aurore - Histoire aléatoire du soir"
-  description: "Joue une histoire aléatoire choisie par Aurore sur son enceinte à 22h00"
+  alias: "Aurore - Meditation aléatoire du soir"
+  description: "Joue une meditation aléatoire choisie par Aurore sur son enceinte à 22h00"
   mode: single
   trigger:
     - device_id: e059cad12f0a2c750a56719a911dc8e6

--- a/automations/chambre_aurore.yaml
+++ b/automations/chambre_aurore.yaml
@@ -47,54 +47,6 @@
         entity_id: light.lumiere_chambre_aurore
       action: light.toggle
   mode: single
-- id: "1677701807876"
-  alias: Aurore's Light color temperature up
-  description: "Augmente la température de couleur de la lumière d'Aurore"
-  trigger:
-    - device_id: e059cad12f0a2c750a56719a911dc8e6
-      domain: zha
-      platform: device
-      type: remote_button_short_press
-      subtype: right
-  condition:
-    - condition: device
-      type: is_on
-      device_id: e87ea47d487bcb4708a442aa8ebacfb1
-      entity_id: light.aurores_light_bulb
-      domain: light
-  action:
-    - device_id: e87ea47d487bcb4708a442aa8ebacfb1
-      domain: number
-      entity_id: number.aurores_light_bulb_start_up_color_temperature
-      type: set_value
-      value:
-        "{{ [states('number.aurores_light_bulb_start_up_color_temperature') |
-        int + 40 , 255] | min | float }}"
-  mode: single
-- id: "1677701807877"
-  alias: Aurore's Light color temperature down
-  description: "Diminue la température de couleur de la lumière d'Aurore"
-  trigger:
-    - device_id: e059cad12f0a2c750a56719a911dc8e6
-      domain: zha
-      platform: device
-      type: remote_button_short_press
-      subtype: left
-  condition:
-    - condition: device
-      type: is_on
-      device_id: e87ea47d487bcb4708a442aa8ebacfb1
-      entity_id: light.aurores_light_bulb
-      domain: light
-  action:
-    - device_id: e87ea47d487bcb4708a442aa8ebacfb1
-      domain: number
-      entity_id: number.aurores_light_bulb_start_up_color_temperature
-      type: set_value
-      value:
-        "{{ [states('number.aurores_light_bulb_start_up_color_temperature') |
-        int - 40 , 255] | min | float }}"
-  mode: single
 - id: "1679085142205"
   alias: During the day Aurore's light bulb default behavior is On
   description: "Pendant la journée, le comportement par défaut de l'ampoule d'Aurore est 'On'"
@@ -176,11 +128,6 @@
       platform: device
       type: remote_button_short_press
       subtype: left
-    - device_id: e059cad12f0a2c750a56719a911dc8e6
-      domain: zha
-      platform: device
-      type: remote_button_long_press
-      subtype: right
   condition: []
   action:
     - if:
@@ -265,8 +212,11 @@
   description: "Joue une histoire aléatoire choisie par Aurore sur son enceinte à 22h00"
   mode: single
   trigger:
-    - platform: time
-      at: "22:00:00"
+    - device_id: e059cad12f0a2c750a56719a911dc8e6
+      domain: zha
+      platform: device
+      type: remote_button_short_press
+      subtype: right
   action:
     - action: media_player.volume_set
       target:
@@ -313,3 +263,17 @@
             "Imagine que tu passes près d'un trou noir - Quand on a besoin de force",
             "Imagine que tu te transforme en Pluton - Quand on a besoin de se retrouver"
           ] | random }}
+- id: "1769000000002"
+  alias: "Stop Aurore music"
+  description: "Arrête la musique d'Aurore"
+  mode: single
+  trigger:
+    - device_id: e059cad12f0a2c750a56719a911dc8e6
+      domain: zha
+      platform: device
+      type: remote_button_long_press
+      subtype: right
+  action:
+    - action: media_player.media_stop
+      target:
+        entity_id: media_player.enceinte_aurore_2

--- a/automations/chambre_aurore.yaml
+++ b/automations/chambre_aurore.yaml
@@ -128,24 +128,56 @@
       platform: device
       type: remote_button_short_press
       subtype: left
+      id: "short"
+    - device_id: e059cad12f0a2c750a56719a911dc8e6
+      domain: zha
+      platform: device
+      type: remote_button_long_press
+      subtype: left
+      id: "long"
   condition: []
   action:
-    - if:
-        - condition: device
-          device_id: 8f16b93c4fae1055fc21ef57afca5b0f
-          domain: cover
-          entity_id: 5159b1462f01722c359983c04fea0e28
-          type: is_closed
-      then:
-        - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
-          domain: cover
-          entity_id: 5159b1462f01722c359983c04fea0e28
-          type: open
-      else:
-        - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
-          domain: cover
-          entity_id: 5159b1462f01722c359983c04fea0e28
-          type: close
+    - choose:
+        - conditions:
+            - condition: trigger
+              id: "short"
+          sequence:
+            - if:
+                - condition: device
+                  device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: is_closed
+              then:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: open
+              else:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: close
+        - conditions:
+            - condition: trigger
+              id: "long"
+          sequence:
+            - if:
+                - condition: device
+                  device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: is_closed
+              then:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: close
+              else:
+                - device_id: 8f16b93c4fae1055fc21ef57afca5b0f
+                  domain: cover
+                  entity_id: 5159b1462f01722c359983c04fea0e28
+                  type: open
   mode: single
 - id: "1758443142653"
   alias: Switch off Aurore bed light when she sleeps


### PR DESCRIPTION
### Description
This PR introduces a new evening automation for Aurore's speaker and revamps her remote button mapping to be more intuitive.

**Key changes & features:**
- **Meditation Automation**: A new automation randomly selects from a curated list of stories/meditations. Favorite tracks are duplicated within the Jinja template to increase their probability.
- **Playback Polish**: Automatically adjusts `media_player.enceinte_aurore_2` volume to 20% and uses `enqueue: replace` to ensure the track plays immediately.
- **Remote Mapping Updates**:
  - **Right Short Press**: Starts the random meditation.
  - **Right Long Press**: Stops the music immediately.
  - **Left Short Press**: Opens/closes the Velux.
  - **Left Long Press**: Fallback inverse logic for the Velux (forces 'Close' if HA thinks it's closed but it's actually open, and vice versa).
- **Cleanup**: Removed obsolete color temperature automations to free up buttons.

### Related Issue
- Addresses HA-63
