### PR TITLE
[HA-65] feat(automation)/ Add cleaning lady automation

### DIFF
--- a/.storage/lovelace.dashboard_admin
+++ b/.storage/lovelace.dashboard_admin
@@ -225,6 +225,16 @@
                   }
                 }
               ]
+            },
+            {
+              "type": "entities",
+              "title": "Présence et Femme de ménage",
+              "entities": [
+                "input_boolean.away_mode",
+                "input_boolean.visitors",
+                "input_datetime.cleaning_lady_start",
+                "input_datetime.cleaning_lady_end"
+              ]
             }
           ]
         },

--- a/automations/README.md
+++ b/automations/README.md
@@ -251,6 +251,10 @@ Automations related to the pink bedroom.
 
 Automations related to heating.
 
+### [Cleaning Lady](cleaning_lady.yaml)
+
+Automations to handle the cleaning lady shift and toggle visitors mode.
+
 ### [Documentation](documentation.yaml)
 
 - `Generate Devices Markdown`: Generates a `devices.md` file listing all

--- a/automations/cleaning_lady.yaml
+++ b/automations/cleaning_lady.yaml
@@ -1,0 +1,30 @@
+# These automations trigger when the cleaning lady arrives and leaves.
+# We set `input_boolean.visitors` to `on` during her shift, to avoid the alarm
+# from going off and suppress other presence-related behaviors.
+#
+# * `Activate visitors mode for cleaning lady`: Turns on visitors when the shift starts.
+# * `Deactivate visitors mode for cleaning lady`: Turns off visitors when the shift ends.
+
+- id: "automation_cleaning_lady_start"
+  alias: Activate visitors mode for cleaning lady
+  description: Active le mode visiteurs pour la femme de ménage
+  trigger:
+    - platform: time
+      at: input_datetime.cleaning_lady_start
+  action:
+    - service: input_boolean.turn_on
+      target:
+        entity_id: input_boolean.visitors
+  mode: single
+
+- id: "automation_cleaning_lady_end"
+  alias: Deactivate visitors mode for cleaning lady
+  description: Désactive le mode visiteurs pour la femme de ménage
+  trigger:
+    - platform: time
+      at: input_datetime.cleaning_lady_end
+  action:
+    - service: input_boolean.turn_off
+      target:
+        entity_id: input_boolean.visitors
+  mode: single

--- a/automations/cleaning_lady.yaml
+++ b/automations/cleaning_lady.yaml
@@ -1,18 +1,18 @@
-# These automations trigger when the cleaning lady arrives and leaves.
-# We set `input_boolean.visitors` to `on` during her shift, to avoid the alarm
-# from going off and suppress other presence-related behaviors.
+# These automations sync `input_boolean.visitors` with the state of `binary_sensor.cleaning_lady_present`.
+# This approach is more robust to restarts and manual changes than using simple time triggers.
 #
-# * `Activate visitors mode for cleaning lady`: Turns on visitors when the shift starts.
-# * `Deactivate visitors mode for cleaning lady`: Turns off visitors when the shift ends.
+# * `Activate visitors mode for cleaning lady`: Turns on visitors when the sensor becomes true.
+# * `Deactivate visitors mode for cleaning lady`: Turns off visitors when the sensor becomes false.
 
 - id: "automation_cleaning_lady_start"
   alias: Activate visitors mode for cleaning lady
   description: Active le mode visiteurs pour la femme de ménage
   trigger:
-    - platform: time
-      at: input_datetime.cleaning_lady_start
+    - platform: state
+      entity_id: binary_sensor.cleaning_lady_present
+      to: "on"
   action:
-    - service: input_boolean.turn_on
+    - action: input_boolean.turn_on
       target:
         entity_id: input_boolean.visitors
   mode: single
@@ -21,10 +21,12 @@
   alias: Deactivate visitors mode for cleaning lady
   description: Désactive le mode visiteurs pour la femme de ménage
   trigger:
-    - platform: time
-      at: input_datetime.cleaning_lady_end
+    - platform: state
+      entity_id: binary_sensor.cleaning_lady_present
+      from: "on"
+      to: "off"
   action:
-    - service: input_boolean.turn_off
+    - action: input_boolean.turn_off
       target:
         entity_id: input_boolean.visitors
   mode: single

--- a/automations/visitors.md
+++ b/automations/visitors.md
@@ -41,3 +41,12 @@ The following vacuum cleaner automation is impacted by the
 * [**vacuum Kitchen and dining room when we are away (Covid version)**](vacuumCleaner.yaml#L143):
   This automation will not run if `input_boolean.visitors` is `on`. This is to
   prevent the vacuum cleaner from disturbing guests.
+
+## Cleaning Lady Automations
+
+The following automations control the `input_boolean.visitors` value:
+
+* [**Activate/Deactivate visitors mode for cleaning lady**](cleaning_lady.yaml):
+  These automations automatically toggle `input_boolean.visitors` on and off
+  based on the cleaning lady's schedule, ensuring that alarms and other
+  presence-based automations do not trigger during her shift.

--- a/entities/input_datetime/cleaning_lady.yaml
+++ b/entities/input_datetime/cleaning_lady.yaml
@@ -1,0 +1,11 @@
+cleaning_lady_start:
+  name: Heure d'arrivée de la femme de ménage
+  has_date: true
+  has_time: true
+  icon: mdi:clock-start
+
+cleaning_lady_end:
+  name: Heure de départ de la femme de ménage
+  has_date: true
+  has_time: true
+  icon: mdi:clock-end

--- a/entities/templates/cleaning_lady.yaml
+++ b/entities/templates/cleaning_lady.yaml
@@ -1,0 +1,7 @@
+- binary_sensor:
+    - name: "Cleaning Lady Present"
+      unique_id: "cleaning_lady_present"
+      state: >-
+        {% set start = states('input_datetime.cleaning_lady_start') | as_datetime %}
+        {% set end = states('input_datetime.cleaning_lady_end') | as_datetime %}
+        {{ start is not none and end is not none and start | as_local <= now() < end | as_local }}


### PR DESCRIPTION
Added functionality to suppress alarms when the cleaning lady arrives.
- Created `input_datetime.cleaning_lady_start` and `cleaning_lady_end` helpers (both date and time)
- Created automations to toggle `input_boolean.visitors` at these times
- Added an entities card to the admin dashboard for managing away mode, visitors mode, and cleaning lady hours
- Documented changes in `automations/visitors.md` and `automations/README.md`

---
*PR created automatically by Jules for task [1984785270041596206](https://jules.google.com/task/1984785270041596206) started by @Giom-V*